### PR TITLE
Add FastAPI orchestrator stack and state management

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,39 @@ The event sink receives dictionaries in the form:
 - `{"type": "job", "data": {"id": "...", "event": "progress", "progress": 0.5}}`
   for job lifecycle notifications.
 
+## REST API & Orchestrator
+
+The project ships with a pre-wired FastAPI application (`cam_slicer.api.app`) that
+exposes the sender, vision, probe, and high-level intent layers. The
+`Orchestrator` class builds on top of the sender to run simple vision-guided
+workflows while keeping calibration data in a global, lock-protected `AppState`.
+
+### Run the API locally
+
+```bash
+uvicorn cam_slicer.api.app:app --reload
+```
+
+Swagger/OpenAPI documentation is available at `http://localhost:8000/docs` once
+the server is running.
+
+### Available endpoints
+
+- `GET /health` – basic readiness probe.
+- `GET /sender/ports`, `POST /sender/open`, `GET /sender/status`, and
+  queue/control helpers under `/sender/*` for G-code streaming.
+- `POST /vision/calibrate`, `/vision/relock`, `/vision/detect` to manage
+  calibration matrices and synthetic detections.
+- `POST /probe/grid` to enqueue raster probing jobs.
+- `/intent/*` routes mapping UI intents (guide, measure, find edges) to
+  orchestrator workflows.
+
+### WebSocket streaming
+
+Connect to `ws://localhost:8000/ws/sender` to receive the same sender events as
+the event sink. Every queued line triggers at least the latest RX echo through
+the websocket so UIs stay in sync.
+
 ## Logging
 
 All internal logs are written to `log.txt` by default. Adjust the Python

--- a/cam_slicer/__init__.py
+++ b/cam_slicer/__init__.py
@@ -1,5 +1,7 @@
 """Core package for Cam Slicer utilities."""
 
+from .core.orchestrator import Orchestrator
+from .core.state import AppState, app_state
 from .sender.service import SenderService
 
-__all__ = ["SenderService"]
+__all__ = ["SenderService", "Orchestrator", "AppState", "app_state"]

--- a/cam_slicer/api/__init__.py
+++ b/cam_slicer/api/__init__.py
@@ -1,0 +1,5 @@
+"""API routers and application factory."""
+
+from .app import app
+
+__all__ = ["app"]

--- a/cam_slicer/api/app.py
+++ b/cam_slicer/api/app.py
@@ -1,0 +1,99 @@
+"""FastAPI application factory wiring routes and singletons."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import List
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from cam_slicer.api.routes_intent import router as intent_router
+from cam_slicer.api.routes_probe import router as probe_router
+from cam_slicer.api.routes_sender import SenderEventManager, router as sender_router
+from cam_slicer.api.routes_vision import router as vision_router
+from cam_slicer.core.orchestrator import Orchestrator
+from cam_slicer.sender.service import SenderService
+
+
+_LOGGER = logging.getLogger(__name__)
+if not _LOGGER.handlers:
+    _LOGGER.setLevel(logging.INFO)
+    _LOG_PATH = Path(__file__).resolve().parents[2] / "log.txt"
+    try:
+        _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _FILE_HANDLER = logging.FileHandler(_LOG_PATH, encoding="utf-8")
+        _FILE_HANDLER.setFormatter(
+            logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+        )
+        _LOGGER.addHandler(_FILE_HANDLER)
+    except OSError:
+        _LOGGER.addHandler(logging.NullHandler())
+else:
+    _LOGGER.addHandler(logging.NullHandler())
+
+
+def _create_app() -> FastAPI:
+    """Internal helper to construct the FastAPI application."""
+
+    app = FastAPI(title="Cam Slicer API", version="2.0")
+
+    sender_service = SenderService()
+    sender_events = SenderEventManager()
+    orchestrator = Orchestrator(sender_service)
+
+    sender_service.set_event_sink(sender_events.publish)
+
+    app.state.sender_service = sender_service
+    app.state.sender_events = sender_events
+    app.state.orchestrator = orchestrator
+
+    allowed_origins: List[str] = [
+        "http://localhost",
+        "http://127.0.0.1",
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+    ]
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=allowed_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    @app.on_event("startup")
+    async def _startup() -> None:
+        """Capture the running loop for event fan-out."""
+
+        loop = asyncio.get_running_loop()
+        sender_events.set_loop(loop)
+        _LOGGER.info("Cam Slicer API ready")
+
+    @app.on_event("shutdown")
+    async def _shutdown() -> None:
+        """Cleanup resources on shutdown."""
+
+        _LOGGER.info("Cam Slicer API shutting down")
+
+    app.include_router(sender_router)
+    app.include_router(vision_router)
+    app.include_router(probe_router)
+    app.include_router(intent_router)
+
+    @app.get("/health")
+    async def health() -> dict:
+        """Simple health check endpoint."""
+
+        return {"status": "ok"}
+
+    return app
+
+
+app = _create_app()
+
+__all__ = ["app"]

--- a/cam_slicer/api/routes_intent.py
+++ b/cam_slicer/api/routes_intent.py
@@ -1,0 +1,124 @@
+"""Intent-level API bridging UI actions to orchestrator flows."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from cam_slicer.core.orchestrator import Orchestrator, OrchestratorError
+
+
+_LOGGER = logging.getLogger(__name__)
+if not _LOGGER.handlers:
+    _LOGGER.setLevel(logging.INFO)
+    _LOG_PATH = Path(__file__).resolve().parents[2] / "log.txt"
+    try:
+        _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _FILE_HANDLER = logging.FileHandler(_LOG_PATH, encoding="utf-8")
+        _FILE_HANDLER.setFormatter(
+            logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+        )
+        _LOGGER.addHandler(_FILE_HANDLER)
+    except OSError:
+        _LOGGER.addHandler(logging.NullHandler())
+else:
+    _LOGGER.addHandler(logging.NullHandler())
+
+
+router = APIRouter(prefix="/intent", tags=["intent"])
+
+
+class GuideToObjectRequest(BaseModel):
+    """Intent payload for guiding the machine to an object."""
+
+    object_class: str = Field(..., alias="class")
+    strategy: str = "center"
+    approach: Optional[float] = Field(default=None, alias="approach")
+    clearance: Optional[float] = Field(default=None, alias="clearance")
+
+    class Config:
+        allow_population_by_field_name = True
+
+
+class MeasureObjectRequest(BaseModel):
+    """Intent payload requesting metrology."""
+
+    object_class: str = Field(..., alias="class")
+    metrics: Optional[List[str]] = None
+
+    class Config:
+        allow_population_by_field_name = True
+
+
+class FindEdgesRequest(BaseModel):
+    """Intent payload for edge detection."""
+
+    mode: str = "rect"
+    return_mode: str = Field(default="points", alias="return")
+
+    class Config:
+        allow_population_by_field_name = True
+
+
+def get_orchestrator(request: Request) -> Orchestrator:
+    """Retrieve orchestrator from FastAPI application state."""
+
+    return request.app.state.orchestrator
+
+
+@router.post("/guide_to_object")
+async def guide_to_object(
+    payload: GuideToObjectRequest, orchestrator: Orchestrator = Depends(get_orchestrator)
+) -> dict:
+    """Invoke the orchestrator guidance workflow."""
+
+    safe_z = payload.approach if payload.approach is not None else 5.0
+    clearance = payload.clearance if payload.clearance is not None else 10.0
+    try:
+        result = await orchestrator.guide_to_object(
+            kind=payload.object_class,
+            strategy=payload.strategy,
+            safe_z=safe_z,
+            xy_clearance=clearance,
+        )
+    except OrchestratorError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return result
+
+
+@router.post("/measure_object")
+async def measure_object(
+    payload: MeasureObjectRequest, orchestrator: Orchestrator = Depends(get_orchestrator)
+) -> dict:
+    """Invoke object measurement routine."""
+
+    try:
+        result = await orchestrator.measure_object(kind=payload.object_class)
+    except OrchestratorError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    if payload.metrics:
+        result["requested_metrics"] = payload.metrics
+    return result
+
+
+@router.post("/find_edges")
+async def find_edges(
+    payload: FindEdgesRequest, orchestrator: Orchestrator = Depends(get_orchestrator)
+) -> dict:
+    """Invoke edge finding routine."""
+
+    try:
+        result = await orchestrator.find_edges(
+            mode=payload.mode,
+            return_mode=payload.return_mode,
+        )
+    except OrchestratorError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return result
+
+
+__all__ = ["router"]

--- a/cam_slicer/api/routes_probe.py
+++ b/cam_slicer/api/routes_probe.py
@@ -1,0 +1,154 @@
+"""Probe-related routes supporting grid sampling."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import List, Optional, Union
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from cam_slicer.core.state import app_state
+from cam_slicer.sender.service import SenderError, SenderService, SenderStateError
+
+
+_LOGGER = logging.getLogger(__name__)
+if not _LOGGER.handlers:
+    _LOGGER.setLevel(logging.INFO)
+    _LOG_PATH = Path(__file__).resolve().parents[2] / "log.txt"
+    try:
+        _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _FILE_HANDLER = logging.FileHandler(_LOG_PATH, encoding="utf-8")
+        _FILE_HANDLER.setFormatter(
+            logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+        )
+        _LOGGER.addHandler(_FILE_HANDLER)
+    except OSError:
+        _LOGGER.addHandler(logging.NullHandler())
+else:
+    _LOGGER.addHandler(logging.NullHandler())
+
+
+router = APIRouter(prefix="/probe", tags=["probe"])
+
+
+class ProbeGridRequest(BaseModel):
+    """Grid probing configuration."""
+
+    roi_mm: List[List[float]] = Field(..., min_items=2, max_items=2)
+    step_mm: Union[float, List[float]]
+    z_clear: float
+    z_probe: float
+    feed_probe: float = Field(..., gt=0)
+    mode: Optional[str] = "raster"
+
+
+def get_sender(request: Request) -> SenderService:
+    """Retrieve the shared sender instance from FastAPI state."""
+
+    return request.app.state.sender_service
+
+
+def _normalize_step(step: Union[float, List[float]]) -> tuple[float, float]:
+    """Convert the ``step_mm`` payload into an (x, y) tuple."""
+
+    if isinstance(step, (int, float)):
+        if step <= 0:
+            raise ValueError("step_mm must be positive")
+        return float(step), float(step)
+    if len(step) != 2:
+        raise ValueError("step_mm must be a scalar or a [x, y] pair")
+    if step[0] <= 0 or step[1] <= 0:
+        raise ValueError("step_mm values must be positive")
+    return float(step[0]), float(step[1])
+
+
+def _generate_grid(roi: List[List[float]], step_x: float, step_y: float) -> List[tuple[float, float]]:
+    """Generate raster grid coordinates for probing."""
+
+    (x0, y0), (x1, y1) = roi
+    x_min, x_max = sorted((x0, x1))
+    y_min, y_max = sorted((y0, y1))
+
+    points: List[tuple[float, float]] = []
+    y = y_min
+    reverse = False
+    while y <= y_max + 1e-9:
+        row: List[tuple[float, float]] = []
+        x = x_min
+        while x <= x_max + 1e-9:
+            row.append((round(x, 6), round(y, 6)))
+            x += step_x
+        if reverse:
+            row.reverse()
+        points.extend(row)
+        y += step_y
+        reverse = not reverse
+    return points
+
+
+async def _enqueue_probe(
+    sender: SenderService,
+    x: float,
+    y: float,
+    z_clear: float,
+    z_probe: float,
+    feed_probe: float,
+) -> str:
+    """Enqueue a single probe point."""
+
+    try:
+        return await asyncio.to_thread(
+            sender.enqueue_probe_point, x, y, z_clear, z_probe, feed_probe
+        )
+    except (SenderError, SenderStateError) as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.post("/grid")
+async def probe_grid(payload: ProbeGridRequest, sender: SenderService = Depends(get_sender)) -> dict:
+    """Queue a grid probing routine covering ``roi_mm``."""
+
+    try:
+        step_x, step_y = _normalize_step(payload.step_mm)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+
+    grid = _generate_grid(payload.roi_mm, step_x, step_y)
+    if not grid:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Empty probing grid")
+
+    job_ids = []
+    for x, y in grid:
+        job_ids.append(
+            await _enqueue_probe(
+                sender,
+                x,
+                y,
+                payload.z_clear,
+                payload.z_probe,
+                payload.feed_probe,
+            )
+        )
+
+    app_state.update(
+        last_heightmap={
+            "roi_mm": payload.roi_mm,
+            "step_mm": [step_x, step_y],
+            "points": len(grid),
+            "mode": payload.mode or "raster",
+        }
+    )
+
+    _LOGGER.info("Queued %d probe points", len(job_ids))
+    return {
+        "count": len(job_ids),
+        "jobs": job_ids,
+        "roi_mm": payload.roi_mm,
+        "mode": payload.mode or "raster",
+    }
+
+
+__all__ = ["router"]

--- a/cam_slicer/api/routes_sender.py
+++ b/cam_slicer/api/routes_sender.py
@@ -1,0 +1,280 @@
+"""FastAPI router exposing GRBL sender operations."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import tempfile
+import threading
+from pathlib import Path
+from typing import Literal
+
+from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile, status
+from pydantic import BaseModel, Field
+from starlette.websockets import WebSocket, WebSocketDisconnect
+
+from cam_slicer.sender.service import (
+    SenderError,
+    SenderService,
+    SenderStateError,
+)
+
+
+_LOGGER = logging.getLogger(__name__)
+if not _LOGGER.handlers:
+    _LOGGER.setLevel(logging.INFO)
+    _LOG_PATH = Path(__file__).resolve().parents[2] / "log.txt"
+    try:
+        _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _FILE_HANDLER = logging.FileHandler(_LOG_PATH, encoding="utf-8")
+        _FILE_HANDLER.setFormatter(
+            logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+        )
+        _LOGGER.addHandler(_FILE_HANDLER)
+    except OSError:
+        _LOGGER.addHandler(logging.NullHandler())
+else:
+    _LOGGER.addHandler(logging.NullHandler())
+
+
+class SenderEventManager:
+    """Thread-safe fan-out for sender events towards websocket clients."""
+
+    def __init__(self) -> None:
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._subscribers: set[asyncio.Queue] = set()
+        self._lock = threading.RLock()
+
+    def set_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Store the asyncio loop used for thread-safe callbacks."""
+
+        self._loop = loop
+
+    def subscribe(self) -> asyncio.Queue:
+        """Register a new queue for websocket consumption."""
+
+        queue: asyncio.Queue = asyncio.Queue()
+        with self._lock:
+            self._subscribers.add(queue)
+        return queue
+
+    def unsubscribe(self, queue: asyncio.Queue) -> None:
+        """Remove a queue from the broadcast list."""
+
+        with self._lock:
+            self._subscribers.discard(queue)
+
+    def publish(self, event: dict) -> None:
+        """Forward events into all subscriber queues."""
+
+        loop = self._loop
+        if loop is None:
+            return
+        with self._lock:
+            subscribers = list(self._subscribers)
+        for queue in subscribers:
+            loop.call_soon_threadsafe(queue.put_nowait, event)
+
+
+router = APIRouter(prefix="/sender", tags=["sender"])
+
+
+class OpenPortRequest(BaseModel):
+    """Request body for opening a serial port."""
+
+    port: str
+    baud: int = 115200
+
+
+class LineRequest(BaseModel):
+    """Single line execution request."""
+
+    gcode: str = Field(..., min_length=1)
+
+
+class JogRequest(BaseModel):
+    """Jog move request."""
+
+    mode: Literal["rel", "abs"]
+    dx: float = 0.0
+    dy: float = 0.0
+    dz: float = 0.0
+    feed: float = Field(default=1500.0, gt=0)
+
+
+class JogResponse(BaseModel):
+    """Response for jogging commands."""
+
+    job_id: str
+
+
+class LineResponse(BaseModel):
+    """Response for queued G-code lines."""
+
+    job_id: str
+
+
+class StreamResponse(BaseModel):
+    """Response when streaming a full G-code program."""
+
+    job_id: str
+    file_path: str
+
+
+def get_sender(request: Request) -> SenderService:
+    """Resolve the shared SenderService from the FastAPI app state."""
+
+    return request.app.state.sender_service
+
+
+def _handle_sender_exception(exc: Exception) -> None:
+    """Convert sender errors into HTTP exceptions."""
+
+    if isinstance(exc, SenderStateError):
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
+    if isinstance(exc, SenderError):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+    raise exc
+
+
+@router.get("/ports")
+async def list_ports(sender: SenderService = Depends(get_sender)) -> dict:
+    """List available serial ports on the host."""
+
+    ports = await asyncio.to_thread(sender.list_ports)
+    return {"ports": ports}
+
+
+@router.post("/open")
+async def open_port(payload: OpenPortRequest, sender: SenderService = Depends(get_sender)) -> dict:
+    """Open a serial connection to the GRBL controller."""
+
+    success, message = await asyncio.to_thread(sender.open, payload.port, payload.baud)
+    if not success:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=message)
+    return {"status": "opened", "port": payload.port, "baud": payload.baud}
+
+
+@router.get("/status")
+async def sender_status(sender: SenderService = Depends(get_sender)) -> dict:
+    """Return the cached machine status snapshot."""
+
+    return await asyncio.to_thread(sender.status)
+
+
+@router.post("/line", response_model=LineResponse)
+async def enqueue_line(payload: LineRequest, sender: SenderService = Depends(get_sender)) -> LineResponse:
+    """Queue a single G-code line."""
+
+    try:
+        job_id = await asyncio.to_thread(sender.enqueue_line, payload.gcode)
+    except Exception as exc:  # pragma: no cover - defensive
+        _handle_sender_exception(exc)
+    return LineResponse(job_id=job_id)
+
+
+@router.post("/jog", response_model=JogResponse)
+async def enqueue_jog(payload: JogRequest, sender: SenderService = Depends(get_sender)) -> JogResponse:
+    """Queue a jog command."""
+
+    try:
+        job_id = await asyncio.to_thread(
+            sender.enqueue_jog,
+            payload.mode,
+            payload.dx,
+            payload.dy,
+            payload.dz,
+            payload.feed,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        _handle_sender_exception(exc)
+    return JogResponse(job_id=job_id)
+
+
+async def _invoke_simple(sender: SenderService, method: str) -> dict:
+    """Invoke a simple sender method without arguments."""
+
+    try:
+        await asyncio.to_thread(getattr(sender, method))
+    except Exception as exc:  # pragma: no cover - defensive
+        _handle_sender_exception(exc)
+    return {"status": method}
+
+
+@router.post("/hold")
+async def hold(sender: SenderService = Depends(get_sender)) -> dict:
+    """Issue the GRBL hold command."""
+
+    return await _invoke_simple(sender, "hold")
+
+
+@router.post("/start")
+async def start(sender: SenderService = Depends(get_sender)) -> dict:
+    """Resume execution after a hold."""
+
+    return await _invoke_simple(sender, "start")
+
+
+@router.post("/reset")
+async def reset(sender: SenderService = Depends(get_sender)) -> dict:
+    """Reset the controller."""
+
+    return await _invoke_simple(sender, "reset")
+
+
+@router.post("/jog_cancel")
+async def jog_cancel(sender: SenderService = Depends(get_sender)) -> dict:
+    """Cancel an active jog."""
+
+    return await _invoke_simple(sender, "jog_cancel")
+
+
+@router.post("/stream", response_model=StreamResponse)
+async def stream_gcode(
+    file: UploadFile = File(...),
+    sender: SenderService = Depends(get_sender),
+) -> StreamResponse:
+    """Stream a G-code file via the sender service."""
+
+    uploads_dir = Path(tempfile.gettempdir()) / "cam_slicer_uploads"
+    uploads_dir.mkdir(parents=True, exist_ok=True)
+    suffix = Path(file.filename or "program.gcode").suffix or ".gcode"
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix, dir=uploads_dir) as tmp:
+        destination = Path(tmp.name)
+        while True:
+            chunk = await file.read(64 * 1024)
+            if not chunk:
+                break
+            tmp.write(chunk)
+    await file.close()
+    _LOGGER.info("Stored upload %s to %s", file.filename, destination)
+
+    try:
+        job_id = await asyncio.to_thread(sender.enqueue_file, str(destination))
+    except Exception as exc:  # pragma: no cover - defensive
+        _handle_sender_exception(exc)
+    return StreamResponse(job_id=job_id, file_path=str(destination))
+
+
+@router.websocket("/ws/sender")
+async def sender_events(websocket: WebSocket) -> None:
+    """Stream sender events over a websocket connection."""
+
+    await websocket.accept()
+    manager: SenderEventManager = websocket.app.state.sender_events
+    sender: SenderService = websocket.app.state.sender_service
+    queue = manager.subscribe()
+    try:
+        await websocket.send_json({"type": "state", "data": await asyncio.to_thread(sender.status)})
+        while True:
+            event = await queue.get()
+            await websocket.send_json(event)
+    except WebSocketDisconnect:
+        _LOGGER.debug("Sender websocket disconnected")
+    except Exception as exc:  # pragma: no cover - defensive
+        _LOGGER.warning("Sender websocket error: %s", exc)
+    finally:
+        manager.unsubscribe(queue)
+
+
+__all__ = ["router", "SenderEventManager"]

--- a/cam_slicer/api/routes_vision.py
+++ b/cam_slicer/api/routes_vision.py
@@ -1,0 +1,203 @@
+"""Vision related FastAPI routes."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from fastapi import APIRouter, File, HTTPException, UploadFile, status
+from pydantic import BaseModel, Field
+
+from cam_slicer.core.state import app_state
+
+
+_LOGGER = logging.getLogger(__name__)
+if not _LOGGER.handlers:
+    _LOGGER.setLevel(logging.INFO)
+    _LOG_PATH = Path(__file__).resolve().parents[2] / "log.txt"
+    try:
+        _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _FILE_HANDLER = logging.FileHandler(_LOG_PATH, encoding="utf-8")
+        _FILE_HANDLER.setFormatter(
+            logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+        )
+        _LOGGER.addHandler(_FILE_HANDLER)
+    except OSError:
+        _LOGGER.addHandler(logging.NullHandler())
+else:
+    _LOGGER.addHandler(logging.NullHandler())
+
+
+router = APIRouter(prefix="/vision", tags=["vision"])
+
+
+class CalibrationRequest(BaseModel):
+    """Payload containing the minimum required calibration triplet."""
+
+    p1_px: List[float] = Field(..., min_items=2, max_items=2)
+    p1_mm: List[float] = Field(..., min_items=2, max_items=2)
+    p2_px: List[float] = Field(..., min_items=2, max_items=2)
+    p2_mm: List[float] = Field(..., min_items=2, max_items=2)
+    p3_px: List[float] = Field(..., min_items=2, max_items=2)
+    p3_mm: List[float] = Field(..., min_items=2, max_items=2)
+    ref_pts_px: Optional[List[List[float]]] = None
+    mode: Optional[str] = "affine"
+
+
+class CalibrationResponse(BaseModel):
+    """Structured calibration response."""
+
+    status: str
+    A_px2cnc: List[List[float]]
+    ref_pts_px: List[List[float]]
+
+
+class RelockResponse(BaseModel):
+    """Response after a relock request."""
+
+    status: str
+    prefer_id: Optional[str] = None
+    frame_bytes: Optional[int] = None
+    filename: Optional[str] = None
+
+
+class Detection(BaseModel):
+    """Detected object description."""
+
+    kind: str
+    confidence: float
+    points: List[List[float]]
+    metadata: dict = Field(default_factory=dict)
+
+
+class DetectionRequest(BaseModel):
+    """Vision detection request."""
+
+    kind: str = "rectangle"
+
+
+def _det3(matrix: List[List[float]]) -> float:
+    """Compute determinant of a 3x3 matrix."""
+
+    return (
+        matrix[0][0] * matrix[1][1] * matrix[2][2]
+        + matrix[0][1] * matrix[1][2] * matrix[2][0]
+        + matrix[0][2] * matrix[1][0] * matrix[2][1]
+        - matrix[0][2] * matrix[1][1] * matrix[2][0]
+        - matrix[0][1] * matrix[1][0] * matrix[2][2]
+        - matrix[0][0] * matrix[1][2] * matrix[2][1]
+    )
+
+
+def _replace_column(matrix: List[List[float]], column: List[float], index: int) -> List[List[float]]:
+    """Return a copy of ``matrix`` with one column replaced."""
+
+    clone = [row[:] for row in matrix]
+    for i in range(3):
+        clone[i][index] = column[i]
+    return clone
+
+
+def _solve_affine(px_pts: List[List[float]], mm_pts: List[List[float]]) -> List[List[float]]:
+    """Solve the affine transformation matrix between pixels and machine space."""
+
+    base = [[px[0], px[1], 1.0] for px in px_pts]
+    det = _det3(base)
+    if abs(det) < 1e-9:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Calibration points are collinear")
+
+    tx = [mm[0] for mm in mm_pts]
+    ty = [mm[1] for mm in mm_pts]
+
+    row_x_det = _det3(_replace_column(base, tx, 0))
+    row_y_det = _det3(_replace_column(base, ty, 0))
+    col_x = [c / det for c in [row_x_det, _det3(_replace_column(base, tx, 1)), _det3(_replace_column(base, tx, 2))]]
+    col_y = [c / det for c in [row_y_det, _det3(_replace_column(base, ty, 1)), _det3(_replace_column(base, ty, 2))]]
+
+    matrix = [
+        [col_x[0], col_x[1], col_x[2]],
+        [col_y[0], col_y[1], col_y[2]],
+        [0.0, 0.0, 1.0],
+    ]
+    return matrix
+
+
+def _transform_points(points: Iterable[Iterable[float]], matrix: List[List[float]]) -> List[List[float]]:
+    """Transform pixel coordinates using the calibration matrix."""
+
+    transformed: List[List[float]] = []
+    for point in points:
+        if len(point) < 2:
+            continue
+        x, y = float(point[0]), float(point[1])
+        vec = (x, y, 1.0)
+        x_mm = matrix[0][0] * vec[0] + matrix[0][1] * vec[1] + matrix[0][2] * vec[2]
+        y_mm = matrix[1][0] * vec[0] + matrix[1][1] * vec[1] + matrix[1][2] * vec[2]
+        if len(matrix) >= 3:
+            w = matrix[2][0] * vec[0] + matrix[2][1] * vec[1] + matrix[2][2] * vec[2]
+            if abs(w) > 1e-9:
+                x_mm /= w
+                y_mm /= w
+        transformed.append([x_mm, y_mm])
+    return transformed
+
+
+@router.post("/calibrate", response_model=CalibrationResponse)
+async def calibrate(payload: CalibrationRequest) -> CalibrationResponse:
+    """Compute the affine transform from three calibration pairs."""
+
+    px_pts = [payload.p1_px, payload.p2_px, payload.p3_px]
+    mm_pts = [payload.p1_mm, payload.p2_mm, payload.p3_mm]
+    matrix = _solve_affine(px_pts, mm_pts)
+    ref_pts = payload.ref_pts_px or px_pts
+    updated = app_state.update(A_px2cnc=matrix, ref_pts_px=ref_pts)
+    _LOGGER.info("Calibration updated via /vision/calibrate")
+    return CalibrationResponse(status="ok", A_px2cnc=matrix, ref_pts_px=updated.ref_pts_px or [])
+
+
+@router.post("/relock", response_model=RelockResponse)
+async def relock(prefer_id: Optional[str] = None, frame: UploadFile | None = File(None)) -> RelockResponse:
+    """Handle relock requests optionally carrying a new frame."""
+
+    frame_bytes = None
+    filename = None
+    if frame is not None:
+        data = await frame.read()
+        frame_bytes = len(data)
+        filename = frame.filename
+        _LOGGER.debug("Received relock frame %s (%d bytes)", filename, frame_bytes)
+
+    if prefer_id:
+        _LOGGER.info("Relock requested with prefer_id=%s", prefer_id)
+
+    return RelockResponse(status="queued", prefer_id=prefer_id, frame_bytes=frame_bytes, filename=filename)
+
+
+@router.post("/detect", response_model=List[Detection])
+async def detect(payload: DetectionRequest) -> List[Detection]:
+    """Return detected objects based on stored calibration data."""
+
+    state = app_state.read()
+    if not state.ref_pts_px:
+        _LOGGER.warning("Detection requested but no reference points are stored")
+        return []
+    if not state.A_px2cnc:
+        return [
+            Detection(kind=payload.kind, confidence=0.5, points=state.ref_pts_px, metadata={"space": "pixels"})
+        ]
+
+    points_mm = _transform_points(state.ref_pts_px, state.A_px2cnc)
+    xs = [pt[0] for pt in points_mm]
+    ys = [pt[1] for pt in points_mm]
+    bbox = [[min(xs), min(ys)], [max(xs), max(ys)]]
+    detection = Detection(
+        kind=payload.kind,
+        confidence=0.9,
+        points=points_mm,
+        metadata={"bbox_mm": bbox},
+    )
+    return [detection]
+
+
+__all__ = ["router"]

--- a/cam_slicer/core/__init__.py
+++ b/cam_slicer/core/__init__.py
@@ -1,0 +1,6 @@
+"""Core utilities for orchestration and shared state."""
+
+from .orchestrator import Orchestrator, OrchestratorError
+from .state import AppState, AppStateStore, app_state
+
+__all__ = ["Orchestrator", "OrchestratorError", "AppState", "AppStateStore", "app_state"]

--- a/cam_slicer/core/orchestrator.py
+++ b/cam_slicer/core/orchestrator.py
@@ -1,0 +1,218 @@
+"""High-level motion orchestration helpers built on top of SenderService."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+from cam_slicer.core.state import AppState, app_state
+from cam_slicer.sender.service import SenderService, SenderStateError
+
+
+_LOGGER = logging.getLogger(__name__)
+if not _LOGGER.handlers:
+    _LOGGER.setLevel(logging.INFO)
+    _LOG_PATH = Path(__file__).resolve().parents[2] / "log.txt"
+    try:
+        _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _FILE_HANDLER = logging.FileHandler(_LOG_PATH, encoding="utf-8")
+        _FILE_HANDLER.setFormatter(
+            logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+        )
+        _LOGGER.addHandler(_FILE_HANDLER)
+    except OSError:
+        _LOGGER.addHandler(logging.NullHandler())
+else:
+    _LOGGER.addHandler(logging.NullHandler())
+
+
+class OrchestratorError(RuntimeError):
+    """Raised when orchestrated workflows cannot be executed."""
+
+
+class Orchestrator:
+    """Coordinate high-level workflows (vision → motion → probing)."""
+
+    def __init__(self, sender: SenderService) -> None:
+        """Store the sender dependency for later asynchronous usage."""
+
+        self._sender = sender
+
+    async def guide_to_object(
+        self,
+        kind: str,
+        strategy: str = "center",
+        safe_z: float = 5.0,
+        xy_clearance: float = 10.0,
+    ) -> dict:
+        """Approach an object using the chosen strategy.
+
+        The function reads calibration data from :mod:`cam_slicer.core.state`. If
+        ``allow_execute_moves`` is ``True`` a simple two-step G-code approach is
+        dispatched (raise Z, then move in XY). Otherwise only the plan is
+        returned so callers can inspect it first.
+        """
+
+        state = self._require_calibration()
+        target_x, target_y = self._resolve_target_point(state, strategy)
+        plan = [f"G0 Z{safe_z:.3f}"]
+        if xy_clearance > 0:
+            approach_y = target_y + xy_clearance
+            plan.append(f"G0 X{target_x:.3f} Y{approach_y:.3f}")
+        plan.append(f"G0 X{target_x:.3f} Y{target_y:.3f}")
+
+        executed = False
+        job_ids: List[str] = []
+        if state.allow_execute_moves:
+            _LOGGER.info(
+                "Executing guide_to_object for %s with plan %s", kind, plan
+            )
+            for line in plan:
+                job_ids.append(await self._enqueue_line(line))
+            executed = True
+        else:
+            _LOGGER.info(
+                "Planning guide_to_object for %s without execution (safety lock)",
+                kind,
+            )
+
+        return {
+            "kind": kind,
+            "strategy": strategy,
+            "target": {"x": target_x, "y": target_y, "safe_z": safe_z},
+            "plan": plan,
+            "executed": executed,
+            "jobs": job_ids,
+        }
+
+    async def measure_object(self, kind: str = "rectangle") -> dict:
+        """Measure object dimensions in machine coordinates."""
+
+        state = self._require_calibration()
+        points_mm = self._transform_points(state.ref_pts_px or [], state)
+        if len(points_mm) < 2:
+            raise OrchestratorError("At least two reference points are required")
+
+        xs = [pt[0] for pt in points_mm]
+        ys = [pt[1] for pt in points_mm]
+        width = max(xs) - min(xs)
+        height = max(ys) - min(ys)
+        diag = (width**2 + height**2) ** 0.5
+
+        _LOGGER.debug(
+            "Measured object kind=%s width=%.3f height=%.3f diag=%.3f",
+            kind,
+            width,
+            height,
+            diag,
+        )
+
+        return {
+            "kind": kind,
+            "points_mm": points_mm,
+            "metrics": {
+                "width_mm": width,
+                "height_mm": height,
+                "diagonal_mm": diag,
+            },
+        }
+
+    async def find_edges(self, mode: str = "rect", return_mode: str = "points") -> dict:
+        """Return edge definitions from the calibrated reference polygon."""
+
+        state = self._require_calibration()
+        points_mm = self._transform_points(state.ref_pts_px or [], state)
+        if not points_mm:
+            raise OrchestratorError("Reference points are missing")
+
+        if return_mode == "points":
+            result = points_mm
+        elif return_mode == "segments":
+            result = [
+                {"start": points_mm[i], "end": points_mm[(i + 1) % len(points_mm)]}
+                for i in range(len(points_mm))
+            ]
+        else:
+            raise OrchestratorError(f"Unsupported return mode: {return_mode}")
+
+        _LOGGER.debug(
+            "find_edges computed %d elements in mode %s", len(points_mm), return_mode
+        )
+
+        return {
+            "mode": mode,
+            "return_mode": return_mode,
+            "edges": result,
+        }
+
+    async def _enqueue_line(self, gcode: str) -> str:
+        """Submit a G-code line using ``asyncio.to_thread`` for safety."""
+
+        try:
+            return await asyncio.to_thread(self._sender.enqueue_line, gcode)
+        except SenderStateError as exc:  # pragma: no cover - defensive
+            raise OrchestratorError(str(exc)) from exc
+
+    def _require_calibration(self) -> AppState:
+        """Ensure calibration data exists before running workflows."""
+
+        state = app_state.read()
+        if not state.A_px2cnc or not state.ref_pts_px:
+            raise OrchestratorError("Calibration matrix or reference points missing")
+        return state
+
+    def _resolve_target_point(self, state: AppState, strategy: str) -> Tuple[float, float]:
+        """Return target XY coordinates in machine space based on strategy."""
+
+        points = self._transform_points(state.ref_pts_px or [], state)
+        if not points:
+            raise OrchestratorError("Reference points missing")
+
+        if strategy == "center":
+            x = sum(pt[0] for pt in points) / len(points)
+            y = sum(pt[1] for pt in points) / len(points)
+        elif strategy == "first":
+            x, y = points[0]
+        elif strategy == "last":
+            x, y = points[-1]
+        else:
+            raise OrchestratorError(f"Unknown strategy: {strategy}")
+        return x, y
+
+    def _transform_points(self, points_px: Iterable[Iterable[float]], state: AppState) -> List[List[float]]:
+        """Transform pixel coordinates into machine space."""
+
+        matrix = state.A_px2cnc
+        if not matrix:
+            raise OrchestratorError("Calibration matrix missing")
+
+        result: List[List[float]] = []
+        for point in points_px:
+            if len(point) < 2:
+                raise OrchestratorError("Invalid pixel coordinate provided")
+            x_px, y_px = float(point[0]), float(point[1])
+            x_mm, y_mm = self._apply_transform(matrix, x_px, y_px)
+            result.append([x_mm, y_mm])
+        return result
+
+    @staticmethod
+    def _apply_transform(matrix: List[List[float]], x: float, y: float) -> Tuple[float, float]:
+        """Apply a homogeneous 3x3 transform to a single point."""
+
+        if len(matrix) < 2 or len(matrix[0]) < 3 or len(matrix[1]) < 3:
+            raise OrchestratorError("Calibration matrix must be at least 3x3")
+
+        vec = (x, y, 1.0)
+        x_mm = matrix[0][0] * vec[0] + matrix[0][1] * vec[1] + matrix[0][2] * vec[2]
+        y_mm = matrix[1][0] * vec[0] + matrix[1][1] * vec[1] + matrix[1][2] * vec[2]
+        if len(matrix) >= 3 and len(matrix[2]) >= 3:
+            w = matrix[2][0] * vec[0] + matrix[2][1] * vec[1] + matrix[2][2] * vec[2]
+            if abs(w) > 1e-9:
+                x_mm /= w
+                y_mm /= w
+        return x_mm, y_mm
+
+
+__all__ = ["Orchestrator", "OrchestratorError"]

--- a/cam_slicer/core/state.py
+++ b/cam_slicer/core/state.py
@@ -1,0 +1,130 @@
+"""Thread-safe global application state container."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from pathlib import Path
+from typing import Callable
+
+try:  # pragma: no cover - optional import for Pydantic v2
+    from pydantic import BaseModel, ConfigDict  # type: ignore
+except ImportError:  # pragma: no cover - fallback for Pydantic v1
+    from pydantic import BaseModel  # type: ignore
+
+    ConfigDict = None  # type: ignore
+
+
+_LOGGER = logging.getLogger(__name__)
+if not _LOGGER.handlers:
+    _LOGGER.setLevel(logging.INFO)
+    _LOG_PATH = Path(__file__).resolve().parents[2] / "log.txt"
+    try:
+        _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _FILE_HANDLER = logging.FileHandler(_LOG_PATH, encoding="utf-8")
+        _FILE_HANDLER.setFormatter(
+            logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+        )
+        _LOGGER.addHandler(_FILE_HANDLER)
+    except OSError:
+        _LOGGER.addHandler(logging.NullHandler())
+else:
+    _LOGGER.addHandler(logging.NullHandler())
+
+
+class AppState(BaseModel):
+    """Structured data shared between orchestrator and API layers."""
+
+    A_px2cnc: list[list[float]] | None = None
+    ref_pts_px: list[list[float]] | None = None
+    last_heightmap: dict | None = None
+    allow_execute_moves: bool = False
+
+    if ConfigDict is not None:  # pragma: no cover - executed under pydantic v2
+        model_config = ConfigDict(
+            str_strip_whitespace=True,
+            validate_assignment=True,
+        )
+    else:  # pragma: no cover - executed under pydantic v1
+        class Config:
+            """Pydantic configuration."""
+
+            anystr_strip_whitespace = True
+            validate_assignment = True
+
+
+def _copy_state(state: AppState, *, update: dict | None = None) -> AppState:
+    """Return a deep copy of ``state`` optionally applying ``update``."""
+
+    kwargs = {"deep": True}
+    if update is not None:
+        kwargs["update"] = update
+    if hasattr(state, "model_copy"):
+        return state.model_copy(**kwargs)  # type: ignore[attr-defined]
+    return state.copy(**kwargs)
+
+
+class AppStateStore:
+    """Lock-protected wrapper around :class:`AppState`."""
+
+    def __init__(self) -> None:
+        """Initialise the state container with a default state."""
+
+        self._lock = threading.RLock()
+        self._state = AppState()
+        _LOGGER.debug("AppStateStore initialised with default state")
+
+    def read(self) -> AppState:
+        """Return a deep copy of the current state.
+
+        The copy ensures callers cannot mutate the underlying storage without
+        acquiring the lock via :meth:`update` or :meth:`mutate`.
+        """
+
+        with self._lock:
+            state_copy = _copy_state(self._state)
+        return state_copy
+
+    def update(self, **changes: object) -> AppState:
+        """Update selected fields atomically and return the new state."""
+
+        with self._lock:
+            self._state = _copy_state(self._state, update=changes)
+            new_state = _copy_state(self._state)
+        _LOGGER.debug("AppState updated: %s", changes)
+        return new_state
+
+    def replace(self, new_state: AppState) -> AppState:
+        """Replace the entire state with ``new_state`` atomically."""
+
+        with self._lock:
+            self._state = _copy_state(new_state)
+            stored = _copy_state(self._state)
+        _LOGGER.debug("AppState replaced")
+        return stored
+
+    def mutate(self, mutator: Callable[[AppState], AppState]) -> AppState:
+        """Apply ``mutator`` to a copy of the state and store the result."""
+
+        with self._lock:
+            proposal = mutator(_copy_state(self._state))
+            if not isinstance(proposal, AppState):  # defensive programming
+                raise TypeError("mutator must return AppState instance")
+            self._state = _copy_state(proposal)
+            stored = _copy_state(self._state)
+        _LOGGER.debug("AppState mutated via callable %s", mutator)
+        return stored
+
+    def reset(self) -> AppState:
+        """Reset the store to a pristine :class:`AppState` instance."""
+
+        with self._lock:
+            self._state = AppState()
+            stored = _copy_state(self._state)
+        _LOGGER.info("AppState reset to defaults")
+        return stored
+
+
+app_state = AppStateStore()
+
+__all__ = ["AppState", "AppStateStore", "app_state"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 pyserial>=3.5
 pydantic>=1.10
+fastapi>=0.103
+uvicorn>=0.22
+python-multipart>=0.0.6

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,70 @@
+"""Tests for orchestrator workflows using a dummy sender."""
+
+import asyncio
+import unittest
+
+from cam_slicer.core.orchestrator import Orchestrator, OrchestratorError
+from cam_slicer.core.state import AppState, app_state
+
+
+class DummySender:
+    """Minimal sender stub capturing queued lines."""
+
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+
+    def enqueue_line(self, gcode: str) -> str:
+        self.lines.append(gcode)
+        return f"job-{len(self.lines)}"
+
+
+class OrchestratorTests(unittest.TestCase):
+    """Validate orchestrator behaviour without hardware."""
+
+    def setUp(self) -> None:
+        app_state.reset()
+        matrix = [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+        refs = [[0.0, 0.0], [10.0, 0.0], [10.0, 5.0]]
+        app_state.replace(AppState(A_px2cnc=matrix, ref_pts_px=refs, allow_execute_moves=True))
+        self.sender = DummySender()
+        self.orchestrator = Orchestrator(self.sender)
+
+    def tearDown(self) -> None:
+        app_state.reset()
+
+    def test_guide_to_object_executes_plan(self) -> None:
+        """Guidance should queue a deterministic three-line approach."""
+
+        result = asyncio.run(self.orchestrator.guide_to_object(kind="rectangle"))
+        self.assertTrue(result["executed"])
+        self.assertEqual(len(self.sender.lines), 3)
+        self.assertEqual(self.sender.lines, result["plan"])
+
+    def test_measure_object_returns_metrics(self) -> None:
+        """Measurement should compute width/height from reference polygon."""
+
+        result = asyncio.run(self.orchestrator.measure_object())
+        self.assertAlmostEqual(result["metrics"]["width_mm"], 10.0)
+        self.assertAlmostEqual(result["metrics"]["height_mm"], 5.0)
+
+    def test_find_edges_segments(self) -> None:
+        """Edge detection should support segment output."""
+
+        result = asyncio.run(self.orchestrator.find_edges(return_mode="segments"))
+        self.assertEqual(len(result["edges"]), 3)
+        self.assertIn("start", result["edges"][0])
+
+    def test_missing_calibration_raises(self) -> None:
+        """Missing calibration data must raise an orchestrator error."""
+
+        app_state.reset()
+        with self.assertRaises(OrchestratorError):
+            asyncio.run(self.orchestrator.measure_object())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,40 @@
+"""Unit tests for the AppStateStore."""
+
+import unittest
+
+from cam_slicer.core.state import AppState, AppStateStore
+
+
+class AppStateStoreTests(unittest.TestCase):
+    """Validate thread-safe state operations."""
+
+    def setUp(self) -> None:
+        self.store = AppStateStore()
+
+    def test_update_and_read_are_isolated(self) -> None:
+        """Updates should persist while reads return defensive copies."""
+
+        updated = self.store.update(allow_execute_moves=True)
+        self.assertTrue(updated.allow_execute_moves)
+        snapshot = self.store.read()
+        snapshot.allow_execute_moves = False
+        self.assertTrue(self.store.read().allow_execute_moves)
+
+    def test_mutate_requires_app_state(self) -> None:
+        """Mutator must return an AppState instance."""
+
+        with self.assertRaises(TypeError):
+            self.store.mutate(lambda _: "invalid")
+
+    def test_replace_and_reset(self) -> None:
+        """Replacing and resetting should restore clean objects."""
+
+        custom = AppState(allow_execute_moves=True)
+        self.store.replace(custom)
+        self.assertTrue(self.store.read().allow_execute_moves)
+        self.store.reset()
+        self.assertFalse(self.store.read().allow_execute_moves)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce a thread-safe AppState store and high-level Orchestrator workflows on top of the sender service
- add FastAPI application wiring sender, vision, probe, and intent routers with websocket event streaming
- document the new API surface, extend requirements, and cover state/orchestrator behaviour with unit tests

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68cfeba84e308333ad9bf75030829eb0